### PR TITLE
Fixing issue #8

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1869,7 +1869,7 @@ canvas {
 /* Loading icon for iframe */
 
 iframe {
-	background-image: url('/images/loading.gif');
+	/* background-image: url('/images/loading.gif'); */
 	background-repeat: no-repeat;
 	background-position: 50% 50%;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1869,8 +1869,8 @@ canvas {
 /* Loading icon for iframe */
 
 iframe {
-	/* background-image: url('/images/loading.gif'); */
-	background-repeat: no-repeat;
+	background-image: url('/images/loading.gif') no-repeat;
+	/* background-repeat: no-repeat; */
 	background-position: 50% 50%;
 }
 


### PR DESCRIPTION
Description: Fixing issue #8 . The loader was running in the background of the iframe of the google form in contact page.

Reason: The cause of the issue was that a loader gif was assigned to the background to the iframe tag in styles.css

Fix: I commented out the line due to which the loader was being shown in the iframe. I tested for various other places where iframe was used such as in jobs, hire etc pages. No issues were coming there due to my commit.