### PR TITLE
On clicking outside modal not closing bug fix

### DIFF
--- a/hire.html
+++ b/hire.html
@@ -534,11 +534,11 @@
 		}
 
 		// When the user clicks anywhere outside of the modal, close it
-		window.onclick = function (event) {
+		window.addEventListener("click", function(event) {
 			if (event.target == modal) {
 				modal.style.display = "none";
 			}
-		}
+		});
 
 		// For Mobile
 


### PR DESCRIPTION
Fix Issue #11 
On Clicking outside the modal in Hire Geeks page, the airtable modal was not getting close but it was working fine in other files. The reason I think was that in this file, there were multiple "window.onClick()" so they might were getting overwrite. So I changed the event handling to "window.addEventListener()". This fixed the issue. Since it was working fine in other files, so I did not change it in other files. 